### PR TITLE
hast-util-raw: Add 2 tests with iframe and textarea

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,6 +1,7 @@
 'use strict';
 
 var Parser = require('parse5/lib/parser');
+var Tokenizer = require('parse5/lib/tokenizer');
 var pos = require('unist-util-position');
 var fromParse5 = require('hast-util-from-parse5');
 var toParse5 = require('hast-util-to-parse5');
@@ -123,6 +124,11 @@ function wrap(tree, file) {
 
     if (!empty) {
       parser._processToken(endTag(node));
+      /* If the parser switch the tokenizer mode then put it back in
+       * the right one, see syntax-tree/hast-util-raw/issues/7 */
+      if (parser.tokenizer.state !== Tokenizer.MODE.DATA) {
+        parser.tokenizer.state = Tokenizer.MODE.DATA;
+      }
     }
   }
 

--- a/test.js
+++ b/test.js
@@ -92,6 +92,30 @@ test('raw', function (t) {
 
   t.deepEqual(
     raw(u('root', [
+      h('iframe', {height: 500, src: 'https://ddg.gg'}),
+      u('raw', '<img alt="foo" src="bar.jpg">')
+    ])),
+    u('root', {data: {quirksMode: false}}, [
+      h('iframe', {height: 500, src: 'https://ddg.gg'}),
+      h('img', {alt: 'foo', src: 'bar.jpg'})
+    ]),
+    'should pass raw nodes through even after iframe'
+  );
+
+  t.deepEqual(
+    raw(u('root', [
+      h('textarea', u('text', 'Some text')),
+      u('raw', '<img alt="foo" src="bar.jpg">')
+    ])),
+    u('root', {data: {quirksMode: false}}, [
+      h('textarea', u('text', 'Some text')),
+      h('img', {alt: 'foo', src: 'bar.jpg'})
+    ]),
+    'should pass raw nodes through even after textarea'
+  );
+
+  t.deepEqual(
+    raw(u('root', [
       u('raw', '<p>Foo, bar!'),
       h('ol', h('li', 'baz'))
     ])),


### PR DESCRIPTION
Hi,

I would like to add to add 2 tests to highlight an old bug. (I met it twice in two different contexts)

The TAP Result : 
```shell
    operator: deepEqual
    expected: |-
      { data: { quirksMode: false }, type: 'root', children: [ { type: 'element', tagName: 'textarea', properties: {}, children: [ { type: 'text', value: 'Some text' } ] }, { type: 'element', tagName: 'img', properties: { alt: 'foo', src: 'bar.jpg' }, children: [] } ] }
    actual: |-
      { type: 'root', children: [ { type: 'element', tagName: 'textarea', properties: {}, children: [ { type: 'text', value: 'Some text' } ] }, { type: 'text', value: '<img alt="foo" src="bar.jpg">' } ], data: { quirksMode: false } }
```

We can see that a raw node is interpreted as text :  `{ type: 'text', value: '<img alt="foo" src="bar.jpg">' }`

This is caused by the fact that the parser of parse5 switch the state of the tokenizer to RCDATA (interpret everything as text i suppose) inside a `iframe` or `textarea` but i doesn't put it back to his normal state.

In fact, the tokenizer should manage his own state as it does with parse5 but it doesn't here. I think it's because hast-util-raw use internal function of parser5.

 ^^