### PR TITLE
Fix: Whitespace characters will incorrectly trigger foster parenting.

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -194,9 +194,14 @@ function text(node, state) {
     state.parser.tokenizer.state = 0
   }
 
+  const isWhitespace = /^[ \t\n\f\r]+$/.test(node.value)
+  const tokenType = isWhitespace
+    ? Token.TokenType.WHITESPACE_CHARACTER
+    : Token.TokenType.CHARACTER
+
   /** @type {Token.CharacterToken} */
   const token = {
-    type: Token.TokenType.CHARACTER,
+    type: tokenType,
     chars: node.value,
     location: createParse5Location(node)
   }

--- a/lib/index.js
+++ b/lib/index.js
@@ -52,6 +52,8 @@ const knownMdxNames = new Set([
   'mdxjsEsm'
 ])
 
+const whitespaceExpression = /^[ \t\n\f\r]+$/
+
 /** @type {ParserOptions<DefaultTreeAdapterMap>} */
 const parseOptions = {sourceCodeLocationInfo: true, scriptingEnabled: false}
 
@@ -194,7 +196,7 @@ function text(node, state) {
     state.parser.tokenizer.state = 0
   }
 
-  const isWhitespace = /^[ \t\n\f\r]+$/.test(node.value)
+  const isWhitespace = whitespaceExpression.test(node.value)
   const tokenType = isWhitespace
     ? Token.TokenType.WHITESPACE_CHARACTER
     : Token.TokenType.CHARACTER

--- a/lib/index.js
+++ b/lib/index.js
@@ -510,7 +510,10 @@ function startTag(node, state) {
   resetTokenizer(state, pointStart(node))
 
   const current = state.parser.openElements.current
-  let ns = 'namespaceURI' in current ? current.namespaceURI : webNamespaces.html
+  let ns =
+    current && 'namespaceURI' in current
+      ? current.namespaceURI
+      : webNamespaces.html
 
   if (ns === webNamespaces.html && tagName === 'svg') {
     ns = webNamespaces.svg
@@ -633,8 +636,8 @@ function documentMode(node) {
   const head = node.type === 'root' ? node.children[0] : node
   return Boolean(
     head &&
-      (head.type === 'doctype' ||
-        (head.type === 'element' && head.tagName.toLowerCase() === 'html'))
+    (head.type === 'doctype' ||
+      (head.type === 'element' && head.tagName.toLowerCase() === 'html'))
   )
 }
 

--- a/test.js
+++ b/test.js
@@ -1017,6 +1017,99 @@ test('raw', async function (t) {
       })
     })
   })
+
+  await t.test(
+    'should not foster-parent whitespace text nodes in tables',
+    async function () {
+      // This equals to HTML:
+      // <table>
+      //   <tbody>
+      //     <tr>
+      //       <td>A</td>
+      //     </tr>
+      //   </tbody>
+      // </table>
+      assert.deepEqual(
+        raw({
+          type: 'root',
+          children: [
+            {
+              type: 'element',
+              tagName: 'table',
+              properties: {},
+              children: [
+                {type: 'text', value: '\n  '},
+                {
+                  type: 'element',
+                  tagName: 'tbody',
+                  properties: {},
+                  children: [
+                    {type: 'text', value: '\n    '},
+                    {
+                      type: 'element',
+                      tagName: 'tr',
+                      properties: {},
+                      children: [
+                        {type: 'text', value: '\n      '},
+                        {
+                          type: 'element',
+                          tagName: 'td',
+                          properties: {},
+                          children: [{type: 'text', value: 'A'}]
+                        },
+                        {type: 'text', value: '\n    '}
+                      ]
+                    },
+                    {type: 'text', value: '\n  '}
+                  ]
+                },
+                {type: 'text', value: '\n'}
+              ]
+            }
+          ]
+        }),
+        {
+          type: 'root',
+          data: {quirksMode: false},
+          children: [
+            {
+              type: 'element',
+              tagName: 'table',
+              properties: {},
+              children: [
+                {type: 'text', value: '\n  '},
+                {
+                  type: 'element',
+                  tagName: 'tbody',
+                  properties: {},
+                  children: [
+                    {type: 'text', value: '\n    '},
+                    {
+                      type: 'element',
+                      tagName: 'tr',
+                      properties: {},
+                      children: [
+                        {type: 'text', value: '\n      '},
+                        {
+                          type: 'element',
+                          tagName: 'td',
+                          properties: {},
+                          children: [{type: 'text', value: 'A'}]
+                        },
+                        {type: 'text', value: '\n    '}
+                      ]
+                    },
+                    {type: 'text', value: '\n  '}
+                  ]
+                },
+                {type: 'text', value: '\n'}
+              ]
+            }
+          ]
+        }
+      )
+    }
+  )
 })
 
 test('integration', async function (t) {


### PR DESCRIPTION
<!--
  Please check the needed checkboxes ([ ] -> [x]).
  Leave the comments as they are: they do not show on GitHub.

  Please try to limit the scope,
  provide a general description of the changes,
  and remember it’s up to you to convince us to land it.

  We are excited about pull requests.
  Thank you!
-->

### Initial checklist

* [x] I read the support docs <!-- https://github.com/syntax-tree/.github/blob/main/support.md -->
* [x] I read the contributing guide <!-- https://github.com/syntax-tree/.github/blob/main/contributing.md -->
* [x] I agree to follow the code of conduct <!-- https://github.com/syntax-tree/.github/blob/main/code-of-conduct.md -->
* [x] I searched issues and discussions and couldn’t find anything or linked relevant results below <!-- https://github.com/search?q=user%3Asyntax-tree&type=issues and https://github.com/orgs/syntax-tree/discussions -->
* [x] I made sure the docs are up to date
* [ ] I included tests (or that’s not needed)

### Description of changes

Fixes #30 

This PR fixes an issue where structural whitespace (like newlines) inside table elements gets incorrectly foster-parented outside the table when passing a hast tree through `rehype-raw`.

Currently, `hast-util-raw` unconditionally maps all text nodes to `Token.TokenType.CHARACTER` when feeding tokens to `parse5`. When `parse5` receives a `CHARACTER` token inside restricted table modes (e.g., `in table body`, `in row`), it treats it as illegal text and triggers HTML5 Foster Parenting, extracting the newlines and flattening the table.

This PR added a regex check `(/^[ \t\n\f\r]+$/)` in the `text()` handler. If the text node contains only HTML whitespace characters, it is correctly mapped to `Token.TokenType.WHITESPACE_CHARACTER`. This allows `parse5` to safely ignore/append the formatting whitespace without breaking the table structure.